### PR TITLE
test: add tests for node registry and node table handling

### DIFF
--- a/src/simstack/models/node_registry.py
+++ b/src/simstack/models/node_registry.py
@@ -108,13 +108,16 @@ class NodeRegistry(Model):
     is_async: bool = False
     parameters: Parameters = Reference()
 
-    @model_validator(mode='before')
+    @model_validator(mode="before")
     @classmethod
-    def convert_project_to_new_project(cls, values):
+    def normalize_project_fields(cls, values):
         if isinstance(values, dict):
-            if 'project' in values and values['project'] is not None and 'new_project' not in values:
-                values['new_project'] = Project(field_name=values['project'])
-                del values['project']
+            legacy_project = values.pop("new_project", None)
+            if values.get("project") is None and legacy_project is not None:
+                if isinstance(legacy_project, Project):
+                    values["project"] = legacy_project.field_name
+                elif isinstance(legacy_project, dict):
+                    values["project"] = legacy_project.get("field_name")
         return values
 
 

--- a/src/simstack/tables/node_table.py
+++ b/src/simstack/tables/node_table.py
@@ -99,6 +99,22 @@ class CreateNodeTable(TableBuilderBase):
 
         return None, None
 
+    @staticmethod
+    def _normalize_docstring_type(type_str: str) -> str:
+        """Strip top-level docstring qualifiers like ', optional' from a parsed type string."""
+        normalized = (type_str or "").strip()
+        bracket_depth = 0
+
+        for index, char in enumerate(normalized):
+            if char == "[":
+                bracket_depth += 1
+            elif char == "]" and bracket_depth > 0:
+                bracket_depth -= 1
+            elif char == "," and bracket_depth == 0:
+                return normalized[:index].strip()
+
+        return normalized
+
     async def _build_outputs(
             self,
             func_name: str,
@@ -132,8 +148,9 @@ class CreateNodeTable(TableBuilderBase):
                 else:
                     for name, data in doc_simstack_result.items():
                         output_mapping = None
+                        output_type = self._normalize_docstring_type(data["type"])
                         try:
-                            wrapper, inner_type_str = self._parse_generic_type(data["type"])
+                            wrapper, inner_type_str = self._parse_generic_type(output_type)
                             if wrapper:
                                 # Handle List[type] or Dict[str,type]
                                 inner_mapping = None
@@ -151,13 +168,13 @@ class CreateNodeTable(TableBuilderBase):
                                         output_mapping = f"List[{inner_mapping}]"
                                     else:  # Dict
                                         output_mapping = f"Dict[str,{inner_mapping}]"
-                            elif "." in data["type"]:
+                            elif "." in output_type:
                                 # It's a full mapping path
-                                output_mapping = data["type"]
+                                output_mapping = output_type
                             else:
                                 # It's a single class name
                                 try:
-                                    output_model = await import_class_by_name(data["type"])
+                                    output_model = await import_class_by_name(output_type)
                                     output_mapping = self.get_class_mapping(output_model, drops)
                                 except (ValueError, LookupError) as e:
                                     logger.error(f"Could not parse '{data['type']}' to mapping: {e}")

--- a/tests/with_context/core/test_node_table.py
+++ b/tests/with_context/core/test_node_table.py
@@ -1,0 +1,43 @@
+import pytest
+
+from simstack.core.context import context
+from simstack.core.simstack_result import SimstackResult
+from simstack.models import FloatData
+from simstack.tables.node_table import CreateNodeTable
+from simstack.util.docstring_parser import DocstringParser
+
+
+def test_normalize_docstring_type_strips_only_top_level_qualifier():
+    assert (
+        CreateNodeTable._normalize_docstring_type("FloatData, optional")
+        == "FloatData"
+    )
+    assert (
+        CreateNodeTable._normalize_docstring_type("Dict[str, FloatData], optional")
+        == "Dict[str, FloatData]"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_outputs_accepts_optional_simstack_result_types():
+    builder = CreateNodeTable(context.db.engine)
+    expected_mapping = builder.get_class_mapping(FloatData, "src")
+    parser = DocstringParser(
+        """
+        SimstackResult:
+            result1 (FloatData, optional): Primary result.
+            result2 (Dict[str, FloatData], optional): Secondary indexed result.
+        """
+    )
+
+    result_mappings = await builder._build_outputs(
+        "test_node",
+        {"return": SimstackResult},
+        parser,
+        "src",
+    )
+
+    assert [(result.name, result.mapping) for result in result_mappings] == [
+        ("result1", expected_mapping),
+        ("result2", f"Dict[str,{expected_mapping}]"),
+    ]

--- a/tests/without_context/test_node_registry_project.py
+++ b/tests/without_context/test_node_registry_project.py
@@ -1,0 +1,36 @@
+from simstack.core.definitions import TaskStatus
+from simstack.models.node_registry import NodeRegistry
+from simstack.models.parameters import Parameters
+
+
+def _build_node_registry(**overrides) -> NodeRegistry:
+    values = {
+        "name": "test-node",
+        "status": TaskStatus.SUBMITTED,
+        "input_ids": [],
+        "input_tables": [],
+        "function_hash": "function-hash",
+        "arg_hash": "arg-hash",
+        "func_mapping": "tests.module.function",
+        "parameters": Parameters(),
+    }
+    values.update(overrides)
+    return NodeRegistry(**values)
+
+
+def test_reassigning_parameters_preserves_project_field():
+    node_registry = _build_node_registry()
+
+    node_registry.parameters = Parameters(queue="slurm-queue")
+
+    assert node_registry.project == "default"
+    assert node_registry.model_dump_doc()["project"] == "default"
+
+
+def test_legacy_new_project_payload_maps_to_project():
+    node_registry = _build_node_registry(
+        project=None,
+        new_project={"field_name": "legacy-project"},
+    )
+
+    assert node_registry.project == "legacy-project"


### PR DESCRIPTION
- Add `_normalize_docstring_type` logic and associated tests for `NodeTable` to ensure proper handling of docstring qualifiers.
- Extend `NodeRegistry` validation for `new_project` and `project` normalization.
- Add unit tests to verify project mapping and parameter preservation in `NodeRegistry`.