### PR TITLE
Feature fix race condition

### DIFF
--- a/src/simstack/core/context.py
+++ b/src/simstack/core/context.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
 from simstack.models.resource_definition import GitRepo
@@ -12,7 +13,6 @@ from simstack.util.mappings import ModelMappingTable, NodeMappingTable
 
 if TYPE_CHECKING:
     from simstack.util.db import Database
-
 
 
 def remove_password_from_connection_string(connection_string):
@@ -29,11 +29,13 @@ def remove_password_from_connection_string(connection_string):
 
     return urlunparse(clean_url)
 
+
 async def initialize_git_list(db: "Database", toml_reader: TomlReader | None):
     git_list = await db.find_all(GitRepo)
     if git_list is None and toml_reader is not None:
         git_list = toml_reader.get("parameters.common.git", [])
     return git_list
+
 
 class GlobalState:
     _instance = None
@@ -134,12 +136,12 @@ class GlobalState:
         self._initialized = True
 
         project_root = kwargs.get("project_root", find_project_root())
-        if project_root is None: # maybe None was passed
+        if project_root is None:  # maybe None was passed
             project_root = find_project_root()
         kwargs["project_root"] = project_root  # overwrite in case it was not set before
-        db_name : str | None = kwargs.get("db_name", None)
+        db_name: str | None = kwargs.get("db_name", None)
         connection_string: str | None = kwargs.get("connection_string", None)
-        db_type: DBType | None = kwargs.get("db_type",None)
+        db_type: DBType | None = kwargs.get("db_type", None)
         is_test = kwargs.get("is_test", False)
 
         toml_reader = None
@@ -158,8 +160,12 @@ class GlobalState:
 
         logger = logging.getLogger("Context")
         if db_info.connection_string is not None:
-            safe_connection_string = remove_password_from_connection_string(db_info.connection_string)
-            logger.info(f"Database connection to {db_type} {safe_connection_string}/{db_name}")
+            safe_connection_string = remove_password_from_connection_string(
+                db_info.connection_string
+            )
+            logger.info(
+                f"Database connection to {db_type} {safe_connection_string}/{db_name}"
+            )
         else:
             logger.info(f"Database connection in_memory {db_type}")
         # here we have a db, we may or may not have a toml reader
@@ -167,17 +173,25 @@ class GlobalState:
         # For testing, we might want to skip ConfigReader if it causes issues
         if not kwargs.get("skip_config", False):
             try:
-                self.config = await ConfigReader.create(resource_str, self.db, toml_reader, **kwargs)
+                self.config = await ConfigReader.create(
+                    resource_str, self.db, toml_reader, **kwargs
+                )
             except Exception as e:
                 if is_test:
-                    logger.warning(f"Failed to initialize ConfigReader in test mode: {e}")
+                    logger.warning(
+                        f"Failed to initialize ConfigReader in test mode: {e}"
+                    )
                 else:
                     raise e
 
         # Initialize memory-loaded mappings
-        self.model_mappings = await ModelMappingTable.load(self.db.engine)
-        self.node_mappings = await NodeMappingTable.load(self.db.engine)
+        await self.refresh_mappings()
 
+    async def refresh_mappings(self, *, models: bool = True, nodes: bool = True):
+        if models:
+            self.model_mappings = await ModelMappingTable.load(self.db.engine)
+        if nodes:
+            self.node_mappings = await NodeMappingTable.load(self.db.engine)
 
     def initialize_logging(self, is_test: bool, log_level: str = "INFO"):
         if is_test:
@@ -196,6 +210,7 @@ class GlobalState:
 
     def initialize_database(self, db_info: DatabaseInformation, is_test: bool):
         from simstack.util.db import Database
+
         try:
             self.db = Database.from_db_info(db_info)
             if db_info.db_type == DBType.MONGODB:
@@ -214,6 +229,7 @@ class GlobalState:
     @property
     def initialized(self):
         return self._initialized
+
 
 # Create the singleton instance, but it's not initialized yet
 context = GlobalState()

--- a/src/simstack/core/context.py
+++ b/src/simstack/core/context.py
@@ -8,6 +8,7 @@ from simstack.util.project_root_finder import find_project_root
 from simstack.util.toml_reader import TomlReader
 from simstack.util.config_reader import ConfigReader
 from simstack.util.setup_logging import setup_logging
+from simstack.util.mappings import ModelMappingTable, NodeMappingTable
 
 if TYPE_CHECKING:
     from simstack.util.db import Database
@@ -46,6 +47,8 @@ class GlobalState:
             cls._instance.log_handler = None
             cls._instance.path_manager = None
             cls._instance.config = None
+            cls._instance.model_mappings: ModelMappingTable = None
+            cls._instance.node_mappings: NodeMappingTable = None
 
         return cls._instance
 
@@ -62,6 +65,8 @@ class GlobalState:
             self.log_handler = None
             self.path_manager = None
             self.config = None
+            self.model_mappings = None
+            self.node_mappings = None
 
             self.initialize(**kwargs)
 
@@ -159,7 +164,19 @@ class GlobalState:
             logger.info(f"Database connection in_memory {db_type}")
         # here we have a db, we may or may not have a toml reader
         resource_str: str = kwargs.get("resource", "self")
-        self.config = await ConfigReader.create(resource_str, self.db, toml_reader, **kwargs)
+        # For testing, we might want to skip ConfigReader if it causes issues
+        if not kwargs.get("skip_config", False):
+            try:
+                self.config = await ConfigReader.create(resource_str, self.db, toml_reader, **kwargs)
+            except Exception as e:
+                if is_test:
+                    logger.warning(f"Failed to initialize ConfigReader in test mode: {e}")
+                else:
+                    raise e
+
+        # Initialize memory-loaded mappings
+        self.model_mappings = await ModelMappingTable.load(self.db.engine)
+        self.node_mappings = await NodeMappingTable.load(self.db.engine)
 
 
     def initialize_logging(self, is_test: bool, log_level: str = "INFO"):

--- a/src/simstack/core/services/resource_branch_monitor_service.py
+++ b/src/simstack/core/services/resource_branch_monitor_service.py
@@ -13,7 +13,7 @@ class ResourceBranchMonitorService(RestartService):
     """
     Monitors the ResourceDefinition for the current resource.
     If the git_branch field changes, it stashes, switches branch, syncs, and restarts.
-
+    """
     def __init__(self, resource: Resource, interval: int):
         super().__init__("ResourceBranchMonitor", resource, interval)
         self._project_dir = context.config.project_root.resolve(strict=True)

--- a/src/simstack/tables/model_table.py
+++ b/src/simstack/tables/model_table.py
@@ -13,6 +13,7 @@ from simstack.tables.table_builder import TableBuilderBase
 
 logger = logging.getLogger("ModelTable")
 
+
 class CreateModelTable(TableBuilderBase):
     """
     Helper class to build the model table without passing around many parameters.
@@ -25,6 +26,10 @@ class CreateModelTable(TableBuilderBase):
     @property
     def logger(self) -> logging.Logger:
         return logger
+
+    async def build(self, *args, **kwargs) -> None:
+        await super().build(*args, **kwargs)
+        await context.refresh_mappings(models=True, nodes=False)
 
     async def _process_module(self, module, drops: str) -> None:
         await self._create_models_from_module(module, drops)
@@ -69,20 +74,22 @@ class CreateModelTable(TableBuilderBase):
             logger.debug(f"    Class: {class_name} Model Mapping: {full_mapping}")
 
             # Remove any existing ModelMapping entry for this class
-            
+
             try:
                 existing_entries = await self.engine.find(
                     ModelMapping, ModelMapping.name == class_name
                 )
             except (ValidationError, NameError, DocumentParsingError) as e:
-                logger.error(f"Error finding existing ModelMapping for {class_name}: {e}")
+                logger.error(
+                    f"Error finding existing ModelMapping for {class_name}: {e}"
+                )
                 existing_entries = []
-            
+
             if len(existing_entries) > 1:
                 error_msg = f"Fatal error: Found {len(existing_entries)} ModelMapping entries for class_name '{class_name}'. Expected at most one."
                 logger.fatal(error_msg)
                 raise RuntimeError(error_msg)
-            
+
             if len(existing_entries) == 1:
                 existing_mapping = existing_entries[0].mapping
                 if existing_mapping != full_mapping:
@@ -98,7 +105,7 @@ class CreateModelTable(TableBuilderBase):
             collection_name = getattr(new_class, "__collection__", None)
             if collection_name is None:
                 if is_embedded_model:
-                    collection_name = f"EmbeddedModel"
+                    collection_name = "EmbeddedModel"
                 else:
                     logger.error(f"No collection specified for {class_name}")
 
@@ -112,7 +119,9 @@ class CreateModelTable(TableBuilderBase):
                     ui_schema=json.dumps(new_class.ui_schema()),
                     route="",
                 )
-                logger.debug(f"SimStack Model: {class_name} Mapping: {full_mapping} Collection: {collection_name}")
+                logger.debug(
+                    f"SimStack Model: {class_name} Mapping: {full_mapping} Collection: {collection_name}"
+                )
                 # open a file in a subdirectory of the current file schema/model.json
                 if self.write_schema:
                     project_root = context.config.project_root
@@ -131,7 +140,9 @@ class CreateModelTable(TableBuilderBase):
                     mapping=full_mapping,
                     collection_name=collection_name,
                 )
-                logger.debug(f"Model: {class_name} Mapping: {full_mapping} Collection: {collection_name}")
+                logger.debug(
+                    f"Model: {class_name} Mapping: {full_mapping} Collection: {collection_name}"
+                )
 
             await self.engine.save(model_entry)
 
@@ -170,6 +181,7 @@ async def make_model_table(
 
 def create_model_table_main():
     TableBuilderBase.cli_main(CreateModelTable)
+
 
 if __name__ == "__main__":
     create_model_table_main()

--- a/src/simstack/tables/node_table.py
+++ b/src/simstack/tables/node_table.py
@@ -5,6 +5,7 @@ from typing import Callable, List, get_type_hints, Dict, Any, Type
 
 
 from simstack.core.simstack_result import SimstackResult
+from simstack.core.context import context
 from simstack.tables.node_children import update_node_children
 from simstack.models import Parameters
 from simstack.models.models import NodeModel, ModelMapping, DataMapping
@@ -32,6 +33,13 @@ class CreateNodeTable(TableBuilderBase):
     @property
     def logger(self) -> logging.Logger:
         return logger
+
+    async def build(self, *args, **kwargs) -> None:
+        if not context.initialized:
+            await context.initialize()
+        await context.refresh_mappings(models=True, nodes=False)
+        await super().build(*args, **kwargs)
+        await context.refresh_mappings(models=False, nodes=True)
 
     async def _process_module(self, module: Any, drops: str) -> None:
         await self._register_nodes_from_module(module, drops)

--- a/src/simstack/util/importer.py
+++ b/src/simstack/util/importer.py
@@ -3,9 +3,7 @@ import logging
 from typing import Callable, Optional, Type
 
 from odmantic import Model, AIOEngine, ObjectId
-from simstack.core.engine import current_engine_context
-from simstack.models.models import ModelMapping, NodeModel
-from simstack.core.context import context
+
 
 logger = logging.getLogger("importer")
 
@@ -57,6 +55,7 @@ async def import_function(
     Returns:
         The imported function object or None if import fails
     """
+    from simstack.core.context import context
     node_mappings = context.node_mappings
     node_model = node_mappings.get_by_mapping(function_path)
 
@@ -81,6 +80,7 @@ async def import_function(
 async def import_function_by_name(
     function_name: str, task_id: ObjectId, engine: AIOEngine = None
 ) -> Optional[Callable]:
+    from simstack.core.context import context
     node_mappings = context.node_mappings
     node_model = node_mappings.get_by_name(function_name)
 
@@ -106,6 +106,7 @@ async def import_class(class_path: str) -> Type[Model] | None:
     """
 
     try:
+        from simstack.core.context import context
         model_mappings = context.model_mappings
         # Split the path into module path and class name
         module_path, class_name = class_path.rsplit(".", 1)
@@ -132,6 +133,7 @@ async def import_class(class_path: str) -> Type[Model] | None:
 
 
 async def import_class_by_name(class_name: str) -> Type[Model]:
+    from simstack.core.context import context
     model_mappings = context.model_mappings
     model_mapping = model_mappings.get_by_name(class_name)
 

--- a/src/simstack/util/importer.py
+++ b/src/simstack/util/importer.py
@@ -5,6 +5,7 @@ from typing import Callable, Optional, Type
 from odmantic import Model, AIOEngine, ObjectId
 from simstack.core.engine import current_engine_context
 from simstack.models.models import ModelMapping, NodeModel
+from simstack.core.context import context
 
 logger = logging.getLogger("importer")
 
@@ -56,17 +57,14 @@ async def import_function(
     Returns:
         The imported function object or None if import fails
     """
-    engine = current_engine_context.get()
+    node_mappings = context.node_mappings
+    node_model = node_mappings.get_by_mapping(function_path)
 
-    node_model = await engine.find_one(
-        NodeModel, NodeModel.function_mapping == function_path
-    )
     if node_model is None and NODES_SEARCH_BY_NAME_FALLBACK:
         _, function_name = function_path.rsplit(".", 1)
-        node_model = await engine.find_one(NodeModel, NodeModel.name == function_name)
+        node_model = node_mappings.get_by_name(function_name)
 
     if node_model is None:
-
         raise LookupError(
             f"task_id: {task_id} Function {function_path} not found in the NodeModel Table"
         )
@@ -79,11 +77,13 @@ async def import_function(
         else:
             raise e
 
-async def import_function_by_name(function_name: str, task_id: ObjectId, engine: AIOEngine = None) -> Optional[Callable]:
-    if not engine:
-        engine = current_engine_context.get()
 
-    node_model = await engine.find_one(NodeModel, NodeModel.name == function_name)
+async def import_function_by_name(
+    function_name: str, task_id: ObjectId, engine: AIOEngine = None
+) -> Optional[Callable]:
+    node_mappings = context.node_mappings
+    node_model = node_mappings.get_by_name(function_name)
+
     if node_model is None:
         logger.error(f"Could not find function mapping for name: {function_name}")
         raise ValueError(f"Could not find function mapping for name: {function_name}")
@@ -106,18 +106,14 @@ async def import_class(class_path: str) -> Type[Model] | None:
     """
 
     try:
-        engine = current_engine_context.get()
+        model_mappings = context.model_mappings
         # Split the path into module path and class name
         module_path, class_name = class_path.rsplit(".", 1)
-        model_mapping = await engine.find_one(
-            ModelMapping, ModelMapping.name == class_name
-        )
+        model_mapping = model_mappings.get_by_name(class_name)
 
-       # If not found by name, try by mapping
+        # If not found by name, try by mapping
         if not model_mapping:
-            model_mapping = await engine.find_one(
-                ModelMapping, ModelMapping.mapping == class_path
-            )
+            model_mapping = model_mappings.get_by_mapping(class_path)
         else:  # when searching by name, the path may have changed
             module_path, class_name = model_mapping.mapping.rsplit(".", 1)
 
@@ -136,8 +132,8 @@ async def import_class(class_path: str) -> Type[Model] | None:
 
 
 async def import_class_by_name(class_name: str) -> Type[Model]:
-    engine = current_engine_context.get()
-    model_mapping = await engine.find_one(ModelMapping, ModelMapping.name == class_name)
+    model_mappings = context.model_mappings
+    model_mapping = model_mappings.get_by_name(class_name)
 
     if not model_mapping:
         logger.error(f"Error finding ModelMapping for {class_name}")

--- a/src/simstack/util/importer.py
+++ b/src/simstack/util/importer.py
@@ -4,13 +4,193 @@ from typing import Callable, Optional, Type
 
 from odmantic import Model, AIOEngine, ObjectId
 
+from simstack.core.engine import current_engine_context
+from simstack.models.models import ModelMapping, NodeModel
 
 logger = logging.getLogger("importer")
 
 NODES_SEARCH_BY_NAME_FALLBACK = True
 MODELS_SEARCH_BY_NAME_FALLBACK = True
 
-async def function_from_model(model, task_id: Optional[ObjectId] = None) -> Optional[Callable]:
+
+def _get_initialized_context():
+    try:
+        from simstack.core.context import context
+
+        if context.initialized:
+            return context
+    except RuntimeError:
+        return None
+    return None
+
+
+def _context_cache_matches_engine(context, engine: AIOEngine = None) -> bool:
+    if context is None:
+        return False
+    if engine is None:
+        return True
+    try:
+        return context.db is not None and engine is context.db.engine
+    except RuntimeError:
+        return False
+
+
+def _resolve_engine(context, engine: AIOEngine = None):
+    if engine is not None:
+        return engine
+    if context is not None:
+        try:
+            if context.db is not None:
+                return context.db.engine
+        except RuntimeError:
+            pass
+    return current_engine_context.get()
+
+
+def _lookup_node_cache(node_mappings, function_path: str) -> Optional[NodeModel]:
+    if node_mappings is None:
+        return None
+    node_model = node_mappings.get_by_mapping(function_path)
+    if node_model is None and NODES_SEARCH_BY_NAME_FALLBACK:
+        _, function_name = function_path.rsplit(".", 1)
+        node_model = node_mappings.get_by_name(function_name)
+    return node_model
+
+
+async def _find_node_model(
+    function_path: str, engine: AIOEngine = None
+) -> Optional[NodeModel]:
+    context = _get_initialized_context()
+    if _context_cache_matches_engine(context, engine):
+        if context.node_mappings is None:
+            await context.refresh_mappings(models=False, nodes=True)
+
+        node_model = _lookup_node_cache(context.node_mappings, function_path)
+        if node_model is not None:
+            return node_model
+
+        await context.refresh_mappings(models=False, nodes=True)
+        node_model = _lookup_node_cache(context.node_mappings, function_path)
+        if node_model is not None:
+            return node_model
+
+    lookup_engine = _resolve_engine(context, engine)
+    if lookup_engine is None:
+        return None
+
+    node_model = await lookup_engine.find_one(
+        NodeModel, NodeModel.function_mapping == function_path
+    )
+    if node_model is None and NODES_SEARCH_BY_NAME_FALLBACK:
+        _, function_name = function_path.rsplit(".", 1)
+        node_model = await lookup_engine.find_one(
+            NodeModel, NodeModel.name == function_name
+        )
+    return node_model
+
+
+async def _find_node_model_by_name(
+    function_name: str, engine: AIOEngine = None
+) -> Optional[NodeModel]:
+    context = _get_initialized_context()
+    if _context_cache_matches_engine(context, engine):
+        if context.node_mappings is None:
+            await context.refresh_mappings(models=False, nodes=True)
+
+        node_model = context.node_mappings.get_by_name(function_name)
+        if node_model is not None:
+            return node_model
+
+        await context.refresh_mappings(models=False, nodes=True)
+        node_model = context.node_mappings.get_by_name(function_name)
+        if node_model is not None:
+            return node_model
+
+    lookup_engine = _resolve_engine(context, engine)
+    if lookup_engine is None:
+        return None
+
+    return await lookup_engine.find_one(NodeModel, NodeModel.name == function_name)
+
+
+def _lookup_model_cache(
+    model_mappings, class_path: str, class_name: str
+) -> Optional[ModelMapping]:
+    if model_mappings is None:
+        return None
+    model_mapping = None
+    if MODELS_SEARCH_BY_NAME_FALLBACK:
+        model_mapping = model_mappings.get_by_name(class_name)
+    if not model_mapping:
+        model_mapping = model_mappings.get_by_mapping(class_path)
+    return model_mapping
+
+
+async def _find_model_mapping(
+    class_path: str, engine: AIOEngine = None
+) -> Optional[ModelMapping]:
+    _, class_name = class_path.rsplit(".", 1)
+    context = _get_initialized_context()
+    if _context_cache_matches_engine(context, engine):
+        if context.model_mappings is None:
+            await context.refresh_mappings(models=True, nodes=False)
+
+        model_mapping = _lookup_model_cache(
+            context.model_mappings, class_path, class_name
+        )
+        if model_mapping is not None:
+            return model_mapping
+
+        await context.refresh_mappings(models=True, nodes=False)
+        model_mapping = _lookup_model_cache(
+            context.model_mappings, class_path, class_name
+        )
+        if model_mapping is not None:
+            return model_mapping
+
+    lookup_engine = _resolve_engine(context, engine)
+    if lookup_engine is None:
+        return None
+
+    model_mapping = None
+    if MODELS_SEARCH_BY_NAME_FALLBACK:
+        model_mapping = await lookup_engine.find_one(
+            ModelMapping, ModelMapping.name == class_name
+        )
+    if model_mapping is None:
+        model_mapping = await lookup_engine.find_one(
+            ModelMapping, ModelMapping.mapping == class_path
+        )
+    return model_mapping
+
+
+async def _find_model_mapping_by_name(
+    class_name: str, engine: AIOEngine = None
+) -> Optional[ModelMapping]:
+    context = _get_initialized_context()
+    if _context_cache_matches_engine(context, engine):
+        if context.model_mappings is None:
+            await context.refresh_mappings(models=True, nodes=False)
+
+        model_mapping = context.model_mappings.get_by_name(class_name)
+        if model_mapping is not None:
+            return model_mapping
+
+        await context.refresh_mappings(models=True, nodes=False)
+        model_mapping = context.model_mappings.get_by_name(class_name)
+        if model_mapping is not None:
+            return model_mapping
+
+    lookup_engine = _resolve_engine(context, engine)
+    if lookup_engine is None:
+        return None
+
+    return await lookup_engine.find_one(ModelMapping, ModelMapping.name == class_name)
+
+
+async def function_from_model(
+    model, task_id: Optional[ObjectId] = None
+) -> Optional[Callable]:
     """
     Loads and retrieves a callable function from a specified model using dynamic import.
     If a task ID is specified, additional logging information is provided regarding the
@@ -30,7 +210,9 @@ async def function_from_model(model, task_id: Optional[ObjectId] = None) -> Opti
     module_path, function_name = function_path.rsplit(".", 1)
 
     if task_id:
-        logger.debug(f"task_id: {task_id} loading function {function_path} using regular import")
+        logger.debug(
+            f"task_id: {task_id} loading function {function_path} using regular import"
+        )
     # Import the module
     module = importlib.import_module(module_path)
     # Get the function from the module
@@ -39,7 +221,9 @@ async def function_from_model(model, task_id: Optional[ObjectId] = None) -> Opti
 
 
 async def import_function(
-    function_path: str, task_id: ObjectId = None, tolerate_missing_function: bool = False
+    function_path: str,
+    task_id: ObjectId = None,
+    tolerate_missing_function: bool = False,
 ) -> Optional[Callable]:
     """
     Dynamically import a function from a module using its full path, including a migration mechanism.
@@ -55,13 +239,7 @@ async def import_function(
     Returns:
         The imported function object or None if import fails
     """
-    from simstack.core.context import context
-    node_mappings = context.node_mappings
-    node_model = node_mappings.get_by_mapping(function_path)
-
-    if node_model is None and NODES_SEARCH_BY_NAME_FALLBACK:
-        _, function_name = function_path.rsplit(".", 1)
-        node_model = node_mappings.get_by_name(function_name)
+    node_model = await _find_node_model(function_path)
 
     if node_model is None:
         raise LookupError(
@@ -80,15 +258,14 @@ async def import_function(
 async def import_function_by_name(
     function_name: str, task_id: ObjectId, engine: AIOEngine = None
 ) -> Optional[Callable]:
-    from simstack.core.context import context
-    node_mappings = context.node_mappings
-    node_model = node_mappings.get_by_name(function_name)
+    node_model = await _find_node_model_by_name(function_name, engine)
 
     if node_model is None:
         logger.error(f"Could not find function mapping for name: {function_name}")
         raise ValueError(f"Could not find function mapping for name: {function_name}")
 
     return await function_from_model(node_model, task_id)
+
 
 async def import_class(class_path: str) -> Type[Model] | None:
     """
@@ -106,16 +283,11 @@ async def import_class(class_path: str) -> Type[Model] | None:
     """
 
     try:
-        from simstack.core.context import context
-        model_mappings = context.model_mappings
         # Split the path into module path and class name
         module_path, class_name = class_path.rsplit(".", 1)
-        model_mapping = model_mappings.get_by_name(class_name)
+        model_mapping = await _find_model_mapping(class_path)
 
-        # If not found by name, try by mapping
-        if not model_mapping:
-            model_mapping = model_mappings.get_by_mapping(class_path)
-        else:  # when searching by name, the path may have changed
+        if model_mapping:
             module_path, class_name = model_mapping.mapping.rsplit(".", 1)
 
         if not model_mapping:
@@ -133,9 +305,7 @@ async def import_class(class_path: str) -> Type[Model] | None:
 
 
 async def import_class_by_name(class_name: str) -> Type[Model]:
-    from simstack.core.context import context
-    model_mappings = context.model_mappings
-    model_mapping = model_mappings.get_by_name(class_name)
+    model_mapping = await _find_model_mapping_by_name(class_name)
 
     if not model_mapping:
         logger.error(f"Error finding ModelMapping for {class_name}")

--- a/src/simstack/util/mappings.py
+++ b/src/simstack/util/mappings.py
@@ -1,0 +1,35 @@
+from typing import Dict, Optional, List
+from simstack.models.models import ModelMapping, NodeModel
+from odmantic import AIOEngine
+
+class ModelMappingTable:
+    def __init__(self, mappings: List[ModelMapping]):
+        self._by_name: Dict[str, ModelMapping] = {m.name: m for m in mappings}
+        self._by_mapping: Dict[str, ModelMapping] = {m.mapping: m for m in mappings}
+
+    def get_by_name(self, name: str) -> Optional[ModelMapping]:
+        return self._by_name.get(name)
+
+    def get_by_mapping(self, mapping: str) -> Optional[ModelMapping]:
+        return self._by_mapping.get(mapping)
+
+    @classmethod
+    async def load(cls, engine: AIOEngine):
+        mappings = await engine.find(ModelMapping)
+        return cls(list(mappings))
+
+class NodeMappingTable:
+    def __init__(self, nodes: List[NodeModel]):
+        self._by_name: Dict[str, NodeModel] = {n.name: n for n in nodes}
+        self._by_mapping: Dict[str, NodeModel] = {n.function_mapping: n for n in nodes}
+
+    def get_by_name(self, name: str) -> Optional[NodeModel]:
+        return self._by_name.get(name)
+
+    def get_by_mapping(self, mapping: str) -> Optional[NodeModel]:
+        return self._by_mapping.get(mapping)
+
+    @classmethod
+    async def load(cls, engine: AIOEngine):
+        nodes = await engine.find(NodeModel)
+        return cls(list(nodes))

--- a/tests/with_context/core/test_mapping_cache.py
+++ b/tests/with_context/core/test_mapping_cache.py
@@ -1,0 +1,168 @@
+import pytest
+from odmantic import Model
+
+from simstack.core.context import context
+from simstack.models.models import ModelMapping, NodeModel, Parameters
+from simstack.util.importer import (
+    import_class,
+    import_class_by_name,
+    import_function,
+    import_function_by_name,
+)
+
+
+def _install_late_model(class_name: str) -> type[Model]:
+    model_class = type(
+        class_name,
+        (Model,),
+        {
+            "__module__": __name__,
+            "__annotations__": {"value": str},
+            "value": "default",
+        },
+    )
+    globals()[class_name] = model_class
+    return model_class
+
+
+def _install_late_function(function_name: str):
+    def late_function(value=None):
+        return value
+
+    late_function.__name__ = function_name
+    late_function.__module__ = __name__
+    globals()[function_name] = late_function
+    return late_function
+
+
+async def _delete_saved_model(saved_model):
+    try:
+        await context.db.delete(saved_model)
+    except Exception:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_import_class_refreshes_stale_model_mapping_cache():
+    class_name = "LateModelMappingCacheByPath"
+    model_class = _install_late_model(class_name)
+    mapping_path = f"{__name__}.{class_name}"
+    model_mapping = ModelMapping(
+        name=class_name,
+        mapping=mapping_path,
+        collection_name="late_model_mapping_cache_by_path",
+    )
+
+    await context.refresh_mappings(models=True, nodes=False)
+    assert context.model_mappings.get_by_name(class_name) is None
+
+    try:
+        await context.db.save(model_mapping)
+        assert context.model_mappings.get_by_name(class_name) is None
+
+        imported_class = await import_class(mapping_path)
+
+        assert imported_class is model_class
+        assert context.model_mappings.get_by_name(class_name) is not None
+    finally:
+        await _delete_saved_model(model_mapping)
+        globals().pop(class_name, None)
+        await context.refresh_mappings(models=True, nodes=False)
+
+
+@pytest.mark.asyncio
+async def test_import_class_by_name_refreshes_stale_model_mapping_cache():
+    class_name = "LateModelMappingCacheByName"
+    model_class = _install_late_model(class_name)
+    mapping_path = f"{__name__}.{class_name}"
+    model_mapping = ModelMapping(
+        name=class_name,
+        mapping=mapping_path,
+        collection_name="late_model_mapping_cache_by_name",
+    )
+
+    await context.refresh_mappings(models=True, nodes=False)
+    assert context.model_mappings.get_by_name(class_name) is None
+
+    try:
+        await context.db.save(model_mapping)
+        assert context.model_mappings.get_by_name(class_name) is None
+
+        imported_class = await import_class_by_name(class_name)
+
+        assert imported_class is model_class
+        assert context.model_mappings.get_by_name(class_name) is not None
+    finally:
+        await _delete_saved_model(model_mapping)
+        globals().pop(class_name, None)
+        await context.refresh_mappings(models=True, nodes=False)
+
+
+@pytest.mark.asyncio
+async def test_import_function_refreshes_stale_node_mapping_cache():
+    function_name = "late_node_mapping_cache_by_path"
+    function = _install_late_function(function_name)
+    function_mapping = f"{__name__}.{function_name}"
+    node_model = NodeModel(
+        name=function_name,
+        function_mapping=function_mapping,
+        description="Late node mapping cache test",
+        input_mappings=[],
+        default_parameters=Parameters(),
+    )
+
+    await context.refresh_mappings(models=False, nodes=True)
+    assert context.node_mappings.get_by_mapping(function_mapping) is None
+
+    try:
+        await context.db.save(node_model)
+        assert context.node_mappings.get_by_mapping(function_mapping) is None
+
+        imported_function = await import_function(function_mapping)
+
+        assert imported_function is function
+        assert imported_function("fresh") == "fresh"
+        assert context.node_mappings.get_by_mapping(function_mapping) is not None
+    finally:
+        await _delete_saved_model(node_model)
+        globals().pop(function_name, None)
+        await context.refresh_mappings(models=False, nodes=True)
+
+
+@pytest.mark.asyncio
+async def test_import_function_by_name_refreshes_stale_node_mapping_cache():
+    function_name = "late_node_mapping_cache_by_name"
+    function = _install_late_function(function_name)
+    function_mapping = f"{__name__}.{function_name}"
+    node_model = NodeModel(
+        name=function_name,
+        function_mapping=function_mapping,
+        description="Late node mapping cache by name test",
+        input_mappings=[],
+        default_parameters=Parameters(),
+    )
+
+    await context.refresh_mappings(models=False, nodes=True)
+    assert context.node_mappings.get_by_name(function_name) is None
+
+    try:
+        await context.db.save(node_model)
+        assert context.node_mappings.get_by_name(function_name) is None
+
+        imported_function = await import_function_by_name(
+            function_name, task_id=None, engine=context.db.engine
+        )
+
+        assert imported_function is function
+        assert imported_function("fresh") == "fresh"
+        assert context.node_mappings.get_by_name(function_name) is not None
+    finally:
+        await _delete_saved_model(node_model)
+        globals().pop(function_name, None)
+        await context.refresh_mappings(models=False, nodes=True)
+
+
+@pytest.mark.asyncio
+async def test_context_mapping_cache_is_populated_after_table_rebuild_setup():
+    assert context.model_mappings.get_by_name("FloatData") is not None
+    assert context.node_mappings.get_by_name("adder_in_tests") is not None


### PR DESCRIPTION
simstack-model has the same branch only for the pyproject.toml file. if this is merged into main the simstack-model branch can be discarded.

ModelMapping and NodeMapping are now read into dicts using mappings.py in simstack/util which are part of Globalstate. 
The imports not  longer use the DB but these dicts. 

For me this workd in adder and orca. 