### PR TITLE
Fix runner table rebuild order

### DIFF
--- a/src/simstack/core/runner.py
+++ b/src/simstack/core/runner.py
@@ -24,7 +24,7 @@ async def initialize_default_resource():
     """
     resource_def = await context.db.find_one(
         ResourceDefinition,
-        ResourceDefinition.resource_str == str(context.config.resource)
+        ResourceDefinition.resource_str == str(context.config.resource),
     )
 
     if resource_def is None:
@@ -50,27 +50,34 @@ async def initialize_default_resource():
                 return resource_def
 
             logger.info(f"Default resource: initializing tables for {active_dirs}")
-            await make_node_table(context.db.engine, dirs=active_dirs)
             await make_model_table(context.db.engine, dirs=active_dirs)
+            await make_node_table(context.db.engine, dirs=active_dirs)
 
         except Exception as e:
             logger.error(f"Failed to initialize default resource tables: {e}")
 
     return resource_def
 
+
 async def async_main(args):
     """Async entry point"""
     await context.initialize(resource=args.resource, db_name=args.db_name)
-    
+
     # Initialize tables if this is the default resource
     resource_def = await initialize_default_resource()
     is_default_resource = bool(resource_def and resource_def.is_default)
 
     if args.resource:
         logger.info(f"Setting resource for runner to {args.resource}")
-        runner_manager = RunnerManager(context.config.resource, detach=args.detach, no_pull=args.no_pull,
-                                       is_default=is_default_resource)
-        await runner_manager.run_nodes_for_resource(args.polling_interval, 10, timeout=args.timeout)
+        runner_manager = RunnerManager(
+            context.config.resource,
+            detach=args.detach,
+            no_pull=args.no_pull,
+            is_default=is_default_resource,
+        )
+        await runner_manager.run_nodes_for_resource(
+            args.polling_interval, 10, timeout=args.timeout
+        )
 
 
 def runner_main():
@@ -97,7 +104,7 @@ def runner_main():
 
     parser.add_argument(
         "--detach",
-        type=lambda x: (str(x).lower() not in ['false', '0', 'no']),
+        type=lambda x: (str(x).lower() not in ["false", "0", "no"]),
         default=True,
         help="If true (default), run nodes in an external process. Set to 'false' to run inline.",
     )

--- a/tests/without_context/test_runner_default_resource.py
+++ b/tests/without_context/test_runner_default_resource.py
@@ -7,7 +7,9 @@ from simstack.core import runner
 
 
 @pytest.mark.asyncio
-async def test_initialize_default_resource_returns_none_when_resource_is_missing(tmp_path, monkeypatch):
+async def test_initialize_default_resource_returns_none_when_resource_is_missing(
+    tmp_path, monkeypatch
+):
     db = SimpleNamespace(find_one=AsyncMock(return_value=None))
     config = SimpleNamespace(resource="docker", project_root=tmp_path)
     monkeypatch.setattr(runner, "context", SimpleNamespace(db=db, config=config))
@@ -18,7 +20,9 @@ async def test_initialize_default_resource_returns_none_when_resource_is_missing
 
 
 @pytest.mark.asyncio
-async def test_initialize_default_resource_keeps_resource_when_config_toml_missing(tmp_path, monkeypatch):
+async def test_initialize_default_resource_keeps_resource_when_config_toml_missing(
+    tmp_path, monkeypatch
+):
     resource_def = SimpleNamespace(is_default=True)
     db = SimpleNamespace(find_one=AsyncMock(return_value=resource_def), engine=object())
     config = SimpleNamespace(resource="docker", project_root=tmp_path)
@@ -37,7 +41,40 @@ async def test_initialize_default_resource_keeps_resource_when_config_toml_missi
 
 
 @pytest.mark.asyncio
-async def test_async_main_uses_false_is_default_when_default_resource_init_returns_none(monkeypatch):
+async def test_initialize_default_resource_builds_model_table_before_node_table(
+    tmp_path, monkeypatch
+):
+    resource_def = SimpleNamespace(is_default=True)
+    engine = object()
+    db = SimpleNamespace(find_one=AsyncMock(return_value=resource_def), engine=engine)
+    config = SimpleNamespace(resource="docker", project_root=tmp_path)
+    (tmp_path / "config.toml").write_text('active_dirs = ["src/simstack/models"]\n')
+    call_order = []
+
+    async def make_model_table(*args, **kwargs):
+        call_order.append(("model", args, kwargs))
+
+    async def make_node_table(*args, **kwargs):
+        call_order.append(("node", args, kwargs))
+
+    monkeypatch.setattr(runner, "context", SimpleNamespace(db=db, config=config))
+    monkeypatch.setattr(runner, "make_model_table", make_model_table)
+    monkeypatch.setattr(runner, "make_node_table", make_node_table)
+
+    result = await runner.initialize_default_resource()
+
+    assert result is resource_def
+    assert [call[0] for call in call_order] == ["model", "node"]
+    assert call_order[0][1] == (engine,)
+    assert call_order[1][1] == (engine,)
+    assert call_order[0][2] == {"dirs": ["src/simstack/models"]}
+    assert call_order[1][2] == {"dirs": ["src/simstack/models"]}
+
+
+@pytest.mark.asyncio
+async def test_async_main_uses_false_is_default_when_default_resource_init_returns_none(
+    monkeypatch
+):
     captured: dict[str, object] = {}
 
     class DummyContext:
@@ -59,7 +96,9 @@ async def test_async_main_uses_false_is_default_when_default_resource_init_retur
             captured["timeout"] = timeout
 
     monkeypatch.setattr(runner, "context", DummyContext())
-    monkeypatch.setattr(runner, "initialize_default_resource", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        runner, "initialize_default_resource", AsyncMock(return_value=None)
+    )
     monkeypatch.setattr(runner, "RunnerManager", DummyRunnerManager)
 
     args = SimpleNamespace(


### PR DESCRIPTION
Fixes #46.\n\nThis hardens default-resource initialization by rebuilding the model table before the node table, so node table generation sees fresh model mappings after runner-driven table rebuilds. Adds a regression test for the rebuild order.