### PR TITLE
uv sync dependency support of user specified extras as an interim solution for not-switched out packages and or to support different envs (gui non gui etc) that require different libraries

### DIFF
--- a/src/simstack/core/services/git_uv_update_service.py
+++ b/src/simstack/core/services/git_uv_update_service.py
@@ -42,7 +42,7 @@ class GitUvUpdateService(RestartService):
             if resource in desired_extras_all.keys:
                 self.desired_extras=desired_extras_all[resource]
         except Exception as e:
-            logger.warning(f"resource {resource} spec  with user file {self._uv_extra_depencency_pyth} failed")
+            logger.warning(f"resource {resource} spec  with user file {self._uv_extra_depencency_pyth} failed with the exception {e}")
 
 
         

--- a/src/simstack/core/services/git_uv_update_service.py
+++ b/src/simstack/core/services/git_uv_update_service.py
@@ -31,6 +31,21 @@ class GitUvUpdateService(RestartService):
         # Resolve project root (assuming we are in src/simstack/core/runner.py)
         self._project_dir = context.config.project_root.resolve(strict=True)
         self._uv_lock_path = context.config.project_root / "uv.lock"
+        self._uv_extra_depencency_pyth = context.config.project_root / "user_extra_config.toml"
+        self.extras=False
+        self.desired_extras=[]
+        #check if the file _uv_extra_depencency_pyth exists if yes - read toml and then extras=True
+        try :
+            import tomllib
+            with open (self._uv_extra_depencency_pyth,"rb") as f:
+                desired_extras_all=tomllib.load(f)
+            if resource in desired_extras_all.keys:
+                self.desired_extras=desired_extras_all[resource]
+        except Exception as e:
+            logger.warning(f"resource {resource} spec  with user file {self._uv_extra_depencency_pyth} failed")
+
+
+        
 
     async def _run_command(self, cmd: list, ignore_error=False) -> str:
         """Run a shell command and return output"""
@@ -64,7 +79,16 @@ class GitUvUpdateService(RestartService):
         # await self._run_command(["git", "stash", "drop"], ignore_error=True)
 
         if git_changed: # or uv_locally_upgraded:
-            await self._run_command(["uv", "sync", "--locked"])  # Update local .venv
+            command_list=["uv", "sync", "--locked"]
+            if self.extras and len(self.desired_extras >0):
+                
+                for desired_extra in self.desired_extras:
+                    command_list.extend(["--extra", str(desired_extra)])
+                    logger.info(f"user specified extra dependency {desired_extra}")
+                    
+                await self._run_command(command_list)  # Update local .venv but with extras as specified by the user for the ressource
+            else:
+                await self._run_command(command_list)  # Update local .venv
             reason = "Git pull" if git_changed else "Local UV upgrade"
             await self.write_resource_event(RunnerEventEnum.SHUTDOWN, message=reason)
             logger.info(f"Update detected ({reason}). Triggering restart...")


### PR DESCRIPTION
I modified the GitUVUpdateService. I have not yet tested it but wanted to know if this is desired. It should now allow me to e.g. add the irmsd back into the OPTIONAL dependencies of the pyproject.toml (and similar packages, which were e.g. in the production branch but got killed) without requiring a total rework of the packages and without cluttering the standard installation, as to get everything working again with minimal modifications.  What are your thoughts? 